### PR TITLE
Feature changement a handlebar pour le build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,36 @@
             <artifactId>picocli</artifactId>
             <version>4.6.3</version>
         </dependency>
-
+        <!-- This is for templating -->
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+            <version>4.3.0</version>
+        </dependency>
+        <!-- This is for md to html convertion-->
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-all</artifactId>
+            <version>0.64.0</version>
+        </dependency>
+        <!-- This is for yaml parsing-->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.21</version>
+        </dependency>
+        <!-- This is to solve a warning see : https://stackoverflow.com/questions/7421612/slf4j-failed-to-load-class-org-slf4j-impl-staticloggerbinder-->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.21</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
         <!-- Testing-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -107,7 +136,7 @@
         <dependency>
             <groupId>com.diffplug.spotless</groupId>
             <artifactId>spotless-maven-plugin</artifactId>
-            <version>2.21.0</version>
+            <version>2.22.0</version>
         </dependency>
     </dependencies>
 

--- a/portfolio.md
+++ b/portfolio.md
@@ -7,7 +7,7 @@ Ce document contient le portfolio du projet de groupe dans le cadre du cours DIL
 
 ## Méthodologie
 
-### Equipe
+### Equipe 
 
 Nous sommes une équipe composée de 4 personnes : Magali Egger, Mélissa Gehring, Joris Schaller et Maëlle Vogel. Nous avons une bonne synergie, nous entendons très bien et avons l'habitude de travailler ensemble. Notre groupe ne comporte à priori pas de leader, nous avons une hiérarchie horizontale.
 

--- a/src/main/java/commands/Build.java
+++ b/src/main/java/commands/Build.java
@@ -1,82 +1,151 @@
 package commands;
 
-import java.io.File;
-import java.io.IOException;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.io.FileTemplateLoader;
+import com.github.jknack.handlebars.io.TemplateLoader;
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.jekyll.tag.JekyllTagExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.data.MutableDataHolder;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import utils.DirectoryDeleter;
+import utils.ParserContentFile;
 
 @Command(name = "build", description = "Build a static site")
 public class Build implements Callable<Integer> {
+    public static final String templateFolderName = "template";
+    public static final String outputFolderName = "build";
+    public static final String contentFolderName = "content";
+    private final String layoutFileName = "layout.html";
 
-    @CommandLine.Parameters(
-            paramLabel = "rootDirectory",
-            description = "root directory of markdown files")
+    @CommandLine.Parameters(paramLabel = "cheminDuSite", description = "chemin du site")
     public File rootDirectory;
+
+    /***
+     * This function test  whether the root directory is a directory containing a static site.
+     * @param rootDirectoryToTest the directory to test
+     */
+    private void testeDirectoryIsRootSite(File rootDirectoryToTest) {
+        if (rootDirectoryToTest == null) {
+            throw new NullPointerException("Le nom de dossier ne peut pas être vide");
+        }
+        if (!rootDirectoryToTest.exists() || !rootDirectoryToTest.isDirectory()) {
+            throw new IllegalArgumentException("Le dossier n'existe pas");
+        }
+
+        if (!Path.of(rootDirectoryToTest.toString(), contentFolderName).toFile().exists()) {
+            throw new IllegalArgumentException(
+                    "Ce site n'a pas de contenu ou ce repertoire ne contient pas de site");
+        }
+
+        if (!Path.of(rootDirectoryToTest.toString(), templateFolderName, "layout.html")
+                .toFile()
+                .exists()) {
+            throw new IllegalArgumentException("Un fichier template/layout.html est nécessaire");
+        }
+        if (!Files.isWritable(Path.of(rootDirectoryToTest.toString()))) {
+            throw new IllegalArgumentException("Le dossier de sortie est en lecture seule");
+        }
+    }
+
+    /**
+     * This function generate the html from the markdown content
+     *
+     * @param markdown the string containing the markdown content
+     * @return the html generated from the markdown content using flexmark
+     */
+    public static String genHtmlFromMarkdown(String markdown) {
+        MutableDataHolder options = new MutableDataSet();
+        options.set(
+                Parser.EXTENSIONS,
+                Arrays.asList(AutolinkExtension.create(), JekyllTagExtension.create()));
+
+        // change soft break to hard break
+        options.set(HtmlRenderer.SOFT_BREAK, "<br/>");
+        Parser parser = Parser.builder(options).build();
+        HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+        Document document = parser.parse(markdown);
+        return renderer.render(document);
+    }
+
+    /**
+     * This function generate the standalone html result from a content file It use the layout file
+     * to generate the html result
+     *
+     * @param contentFile the content file having meta info the '---' separator and the markdown
+     *     content
+     * @return The html result generated from the content file using the layout file
+     */
+    public String createHtmlFromContentFile(@NotNull File contentFile) {
+        try {
+            var contentAndMeta =
+                    ParserContentFile.parse(new BufferedReader(new FileReader(contentFile)));
+
+            contentAndMeta.put(
+                    "content", genHtmlFromMarkdown((String) contentAndMeta.get("content")));
+
+            TemplateLoader loader = new FileTemplateLoader(rootDirectory + "/template", ".html");
+            Handlebars handlebars = new Handlebars(loader);
+            Template template = handlebars.compile("layout");
+            return template.apply(contentAndMeta);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.err.println("Erreur lors de la création du résultat " + e.getMessage());
+        }
+        return null;
+    }
 
     @Override
     public Integer call() throws IOException {
-        // check param exists
-        if (rootDirectory == null) {
-            throw new NullPointerException("Le nom de dossier ne peut pas être vide");
+        testeDirectoryIsRootSite(rootDirectory);
+
+        File buildDir = Path.of(rootDirectory.getPath(), outputFolderName).toFile();
+        if (buildDir.exists() && buildDir.isDirectory()) DirectoryDeleter.delete(buildDir);
+        if (!buildDir.mkdir()) {
+            Logger.getAnonymousLogger()
+                    .log(
+                            Level.SEVERE,
+                            "Erreur lors de la création du dossier '" + buildDir.getName() + "'");
+            return -1;
+        }
+        var contentFolder = new File(rootDirectory + "/" + contentFolderName);
+        if (!contentFolder.isDirectory()) {
+            throw new NullPointerException("Le dossier de contenu n'existe pas");
         }
 
-        if (rootDirectory.exists()) {
-            if (rootDirectory.isDirectory()) {
-
-                String[] file = rootDirectory.list();
-
-                assert file != null;
-                // the directory must not be empty
-                if (file.length == 0) {
-                    System.err.println("Error: Empty directory");
-                    return -1;
-                }
-
-                // create dir build
-                Files.createDirectories(Path.of(rootDirectory + "/build"));
-
-                // read each file
-                for (String md : file) {
-                    File md_file = new File(rootDirectory + "/" + md);
-
-                    // only parse if it's a file
-                    if (md_file.isFile()) {
-
-                        String name = md_file.getName();
-                        int ext = name.lastIndexOf('.');
-                        String extension = name.substring(ext);
-
-                        // check extension is md
-                        if (extension.equals(".md")) {
-                            String fileNameWithOutExt = name.substring(0, ext);
-
-                            Runtime runtime = Runtime.getRuntime();
-                            String command =
-                                    "pandoc --standalone -o "
-                                            + rootDirectory
-                                            + "/build/"
-                                            + fileNameWithOutExt
-                                            + ".html "
-                                            + rootDirectory
+        for (File file : Objects.requireNonNull(contentFolder.listFiles())) {
+            if (file.getName().endsWith(".md")) {
+                String result = createHtmlFromContentFile(file);
+                if (result != null) {
+                    File htmlFile =
+                            new File(
+                                    rootDirectory
                                             + "/"
-                                            + fileNameWithOutExt
-                                            + ".md";
-                            runtime.exec(command);
-                        }
-                    }
+                                            + outputFolderName
+                                            + "/"
+                                            + file.getName().replace(".md", ".html"));
+                    Files.write(htmlFile.toPath(), result.getBytes());
                 }
-
             } else {
-                System.err.println("Error: not a directory");
-                return -1;
+                // copy the file to the build folder using the file name
+                Files.copy(
+                        file.toPath(),
+                        Path.of(buildDir.toString(), file.getName()).toFile().toPath());
             }
-
-        } else {
-            System.err.println("Error: incorrect directory");
-            return -1;
         }
 
         return 0;

--- a/src/main/java/utils/DirectoryDeleter.java
+++ b/src/main/java/utils/DirectoryDeleter.java
@@ -1,0 +1,18 @@
+package utils;
+
+import java.io.File;
+import java.nio.file.Files;
+
+public class DirectoryDeleter {
+    public static void delete(File file) {
+        File[] contents = file.listFiles();
+        if (contents != null) {
+            for (File f : contents) {
+                if (!Files.isSymbolicLink(f.toPath())) {
+                    delete(f);
+                }
+            }
+        }
+        file.delete();
+    }
+}

--- a/src/main/java/utils/ParserContentFile.java
+++ b/src/main/java/utils/ParserContentFile.java
@@ -1,0 +1,56 @@
+package utils;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.util.HashMap;
+import org.yaml.snakeyaml.Yaml;
+
+/***
+ * This class is used to parse the reader, it split the content at ---
+ * then it parse as yaml the first half and keep the rest as a string
+ * If there is no --- it will return the whole as the content
+ */
+public class ParserContentFile {
+    public static HashMap<String, Object> parse(BufferedReader reader) {
+        if (reader == null) {
+            return new HashMap<>();
+        }
+        StringBuilder sb = new StringBuilder();
+        String yaml = null;
+        String content = null;
+        boolean isYaml = true;
+        try {
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                // skip blanck lines only when parsing yaml
+                if (line.isBlank() && isYaml) continue;
+                if (line.equals("---")) {
+                    isYaml = false;
+                    yaml = sb.toString();
+                    sb.delete(0, sb.length());
+                    continue;
+                }
+                sb.append(line).append("\n");
+            }
+            // delete the last \n
+            if (sb.length() > 0) {
+                sb.deleteCharAt(sb.length() - 1);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        content = sb.toString();
+        HashMap<String, Object> documentMap = new HashMap<>();
+        if (yaml != null) {
+            var mapYaml = (HashMap<String, Object>) new Yaml().load(new StringReader(yaml));
+            if (mapYaml != null) {
+                documentMap.putAll(mapYaml);
+            }
+        }
+        if (!content.trim().isBlank()) {
+            documentMap.put("content", content);
+        }
+        return documentMap;
+    }
+}

--- a/src/main/resources/exempleSite/content/about.md
+++ b/src/main/resources/exempleSite/content/about.md
@@ -1,0 +1,8 @@
+author: Waluigi
+date: 2022-25-04
+title: Blog 1
+---
+# Ceci est mon titre
+## Ceci est mon sous-titre
+### Mais pourquoi encore un titre ?
+Attaquons les choses avec un peu de contenu !

--- a/src/main/resources/exempleSite/content/index.md
+++ b/src/main/resources/exempleSite/content/index.md
@@ -2,6 +2,6 @@ title: Mon premier article
 author: Jane Doe
 date: March 31, 2022
 ---
-# Mon premier article by 
+# Mon premier article  
 ## Mon sous-titre
 Le contenu de mon article.

--- a/src/main/resources/exempleSite/content/index.md
+++ b/src/main/resources/exempleSite/content/index.md
@@ -1,8 +1,7 @@
----
 title: Mon premier article
 author: Jane Doe
 date: March 31, 2022
 ---
-# Mon premier article
+# Mon premier article by 
 ## Mon sous-titre
 Le contenu de mon article.

--- a/src/main/resources/exempleSite/template/footer.html
+++ b/src/main/resources/exempleSite/template/footer.html
@@ -1,0 +1,1 @@
+<h1>HTML venant du fichier footer.html</h1>

--- a/src/main/resources/exempleSite/template/header.html
+++ b/src/main/resources/exempleSite/template/header.html
@@ -1,0 +1,1 @@
+<h1>HTML venant du fichier header.html</h1>

--- a/src/main/resources/exempleSite/template/layout.html
+++ b/src/main/resources/exempleSite/template/layout.html
@@ -1,0 +1,16 @@
+<html lang="en">
+<head>
+<meta charset="utf-8">
+    <meta charset="UTF-8">
+    <meta name="description" content="{{description}}">
+     <meta name="author" content="{{author}}">
+    <meta name="date" content="{{date}}">
+    <title>{{title}}</title>
+</head>
+
+<body>
+{{>header}}
+{{{ content }}}
+{{>footer}}
+</body>
+</html>

--- a/src/main/resources/index.md
+++ b/src/main/resources/index.md
@@ -1,0 +1,7 @@
+title: Mon premier article
+author: Jane Doe
+date: March 31, 2022
+---
+# Mon premier article
+## Mon sous-titre
+Le contenu de mon article.

--- a/src/test/java/commands/BuildTest.java
+++ b/src/test/java/commands/BuildTest.java
@@ -4,11 +4,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
-import org.apache.commons.io.FileUtils;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.*;
 import utils.DirectoryDeleter;
 
@@ -145,19 +145,20 @@ public class BuildTest {
         DirectoryDeleter.delete(directory3);
     }
 
-
     @Test
     void genHtmlFromMarkdown() {
         String markdown = "# Hello World";
         String html = Build.genHtmlFromMarkdown(markdown);
         assertEquals("<h1>Hello World</h1>\n", html);
     }
+
     @Test
     void genHtmlFromMarkdownHeader2() {
         String markdown = "## Hello World";
         String html = Build.genHtmlFromMarkdown(markdown);
         assertEquals("<h2>Hello World</h2>\n", html);
     }
+
     @Test
     void genHtmlFromMarkdownHeader3() {
         String markdown = "### Hello World";
@@ -168,33 +169,32 @@ public class BuildTest {
     void setUp() throws IOException, URISyntaxException {
         var ri = Build.class.getClassLoader().getResource("exempleSite");
         try {
-            var srcFile =  Path.of(ri.getPath()).toFile();
-            FileUtils.copyDirectory( srcFile, Path.of(siteFolderName).toFile());
+            var srcFile = Path.of(ri.getPath()).toFile();
+            FileUtils.copyDirectory(srcFile, Path.of(siteFolderName).toFile());
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
-
     void tearDown() {
         DirectoryDeleter.delete(new File(siteFolderName));
     }
+
     @Test
     void createHtmlFromContentFile() {
-        try{
+        try {
             setUp();
             Build b = new Build();
             b.rootDirectory = new File(siteFolderName);
             b.call();
-            var index = Path.of(siteFolderName.toString(), "build","index.html").toFile();
-            assert(index.exists());
-            //there should be template, content, and build
+            var index = Path.of(siteFolderName.toString(), "build", "index.html").toFile();
+            assert (index.exists());
+            // there should be template, content, and build
             var site = Path.of(siteFolderName).toFile();
             assertTrue(site.exists());
             assertNotNull(site.list());
-            assertEquals( 3,site.list().length);
-        }
-        catch (Exception e){
+            assertEquals(3, site.list().length);
+        } catch (Exception e) {
             e.printStackTrace();
             System.err.println("Erreur" + e.getMessage());
         }

--- a/src/test/java/commands/BuildTest.java
+++ b/src/test/java/commands/BuildTest.java
@@ -4,12 +4,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import utils.DirectoryDeleter;
 
 public class BuildTest {
     private static final String TEST_PATH = "test1/";
@@ -21,18 +22,34 @@ public class BuildTest {
 
     // empty directory
     private static final String TEST_PATH_3 = "test3/";
+    private final String siteFolderName = "site";
 
     @BeforeAll
     public static void CreateDirectory() throws IOException {
-        Files.createDirectories(Path.of("test1/"));
-        Files.createDirectories(Path.of(TEST_PATH_1));
-        Files.createFile(Path.of(TEST_PATH_1 + "fichier2.md"));
-        Files.createFile(Path.of(TEST_PATH_1 + "test.md"));
-        Files.createDirectories(Path.of(TEST_PATH_3));
+        try {
+            Files.createDirectories(Path.of(TEST_PATH));
+            Files.createDirectories(Path.of(TEST_PATH_1, Build.contentFolderName));
+            File f = new File(TEST_PATH_1 + "/" + Build.contentFolderName);
+            f.setWritable(true);
+            Files.createDirectories(Path.of(TEST_PATH_1, Build.templateFolderName));
+            Files.createFile(Path.of(TEST_PATH_1, Build.contentFolderName, "index.md"));
+            Files.createFile(Path.of(TEST_PATH_1, Build.templateFolderName, "layout.html"));
+
+            Files.createDirectories(Path.of(TEST_PATH));
+            Files.createDirectories(Path.of(TEST_PATH_2, Build.contentFolderName));
+            Files.createDirectories(Path.of(TEST_PATH_2, Build.templateFolderName));
+            Files.createFile(Path.of(TEST_PATH_2, Build.contentFolderName, "content.md"));
+            Files.createFile(Path.of(TEST_PATH_2, Build.templateFolderName, "layout.html"));
+            Files.createDirectories(Path.of(TEST_PATH_3));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.err.println(e.getMessage());
+        }
     }
 
     @Test
-    public void testBuildWithoutParameterThrowsException() {
+    public void testBuildWithoutParameterFails() {
         Build build = new Build();
         // assert que build sans paramètre lance une exception
         NullPointerException thrown = assertThrows(NullPointerException.class, build::call);
@@ -42,17 +59,23 @@ public class BuildTest {
     @Test
     public void testBuildWithParameterWorks() throws IOException {
         Build build = new Build();
-        build.rootDirectory = new File(TEST_PATH_1);
+        File f = new File(TEST_PATH_1);
+        f.setWritable(true);
+
+        build.rootDirectory = f;
         // assert que build retourne sans erreur
-        assertEquals(build.call(), 0);
+        assertEquals(0, build.call());
     }
 
     @Test
     public void testBuildOnDirectoryThatDoesntExistsDoesntWork() throws IOException {
         Build build = new Build();
-        build.rootDirectory = new File(TEST_PATH_2);
+        build.rootDirectory = new File(TEST_PATH_3);
         // assert que build retourne avec erreur
-        assertEquals(build.call(), -1);
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, build::call);
+        assertEquals(
+                "Ce site n'a pas de contenu ou ce repertoire ne contient pas de site",
+                thrown.getMessage());
     }
 
     @Test
@@ -60,23 +83,26 @@ public class BuildTest {
         Build build = new Build();
         build.rootDirectory = new File(TEST_PATH_1 + "/test.md");
         // assert que build retourne avec erreur
-        assertEquals(build.call(), -1);
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, build::call);
+        assertEquals("Le dossier n'existe pas", thrown.getMessage());
     }
 
     @Test
     public void testBuildOnEmptyDirectoryDoesntWork() throws IOException {
         Build build = new Build();
         build.rootDirectory = new File(TEST_PATH_3);
-        // assert que build retourne avec erreur
-        assertEquals(build.call(), -1);
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, build::call);
+        assertEquals(
+                "Ce site n'a pas de contenu ou ce repertoire ne contient pas de site",
+                thrown.getMessage());
     }
 
     @Test
     public void testBuildOnInvalidParameterDoesntWork() throws IOException {
         Build build = new Build();
         build.rootDirectory = new File("*qwert");
-        // assert que build retourne avec erreur
-        assertEquals(build.call(), -1);
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, build::call);
+        assertEquals("Le dossier n'existe pas", thrown.getMessage());
     }
 
     @Test
@@ -84,7 +110,7 @@ public class BuildTest {
         Build build = new Build();
         build.rootDirectory = new File(TEST_PATH_1);
         // assert que build retourne sans erreur
-        assertEquals(build.call(), 0);
+        assertEquals(0, build.call());
 
         File dir = new File(TEST_PATH_1 + "build/");
         assertTrue(dir.exists());
@@ -101,25 +127,77 @@ public class BuildTest {
         String[] result = dir.list();
         assert result != null;
         Arrays.sort(result);
-        String[] except = {"fichier2.html", "test.html"};
-        assertArrayEquals(result, except);
+        String[] expect = {"index.html"};
+        assertArrayEquals(expect, result);
     }
 
     @AfterAll
     public static void deleteDirectories() {
-        File directory1 = new File(TEST_PATH);
-        deleteDirectory(directory1);
-        File directory2 = new File(TEST_PATH_3);
-        deleteDirectory(directory2);
+        File directory = new File(TEST_PATH);
+        DirectoryDeleter.delete(directory);
+        File dir = new File("test2");
+        DirectoryDeleter.delete(dir);
+        File directory1 = new File(TEST_PATH_1);
+        DirectoryDeleter.delete(directory1);
+        File directory2 = new File(TEST_PATH_2);
+        DirectoryDeleter.delete(directory2);
+        File directory3 = new File(TEST_PATH_3);
+        DirectoryDeleter.delete(directory3);
     }
 
-    private static void deleteDirectory(File directory) {
-        File[] allContents = directory.listFiles();
-        if (allContents != null) {
-            for (File file : allContents) {
-                deleteDirectory(file);
-            }
+
+    @Test
+    void genHtmlFromMarkdown() {
+        String markdown = "# Hello World";
+        String html = Build.genHtmlFromMarkdown(markdown);
+        assertEquals("<h1>Hello World</h1>\n", html);
+    }
+    @Test
+    void genHtmlFromMarkdownHeader2() {
+        String markdown = "## Hello World";
+        String html = Build.genHtmlFromMarkdown(markdown);
+        assertEquals("<h2>Hello World</h2>\n", html);
+    }
+    @Test
+    void genHtmlFromMarkdownHeader3() {
+        String markdown = "### Hello World";
+        String html = Build.genHtmlFromMarkdown(markdown);
+        assertEquals("<h3>Hello World</h3>\n", html);
+    }
+
+    void setUp() throws IOException, URISyntaxException {
+        var ri = Build.class.getClassLoader().getResource("exempleSite");
+        try {
+            var srcFile =  Path.of(ri.getPath()).toFile();
+            FileUtils.copyDirectory( srcFile, Path.of(siteFolderName).toFile());
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-        directory.delete();
+    }
+
+
+    void tearDown() {
+        DirectoryDeleter.delete(new File(siteFolderName));
+    }
+    @Test
+    void createHtmlFromContentFile() {
+        try{
+            setUp();
+            Build b = new Build();
+            b.rootDirectory = new File(siteFolderName);
+            b.call();
+            var index = Path.of(siteFolderName.toString(), "build","index.html").toFile();
+            assert(index.exists());
+            //there should be template, content, and build
+            var site = Path.of(siteFolderName).toFile();
+            assertTrue(site.exists());
+            assertNotNull(site.list());
+            assertEquals( 3,site.list().length);
+        }
+        catch (Exception e){
+            e.printStackTrace();
+            System.err.println("Erreur" + e.getMessage());
+        }
+        tearDown();
     }
 }

--- a/src/test/java/utils/DirectoryDeleterTest.java
+++ b/src/test/java/utils/DirectoryDeleterTest.java
@@ -1,0 +1,32 @@
+package utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+public class DirectoryDeleterTest {
+    @Test
+    public void testDeleteDirectoryWithContent() throws Exception {
+        File folder = new File("folderWithContent");
+        folder.mkdir();
+        var file = new File("folderWithContent/file1");
+        file.createNewFile();
+        assertTrue(file.exists());
+
+        DirectoryDeleter.delete(file);
+        assertFalse(file.exists());
+        DirectoryDeleter.delete(folder);
+        assertFalse(folder.exists());
+    }
+
+    @Test
+    public void testDeleteEmptyDirectory() throws Exception {
+        File folder = new File("folderWithContent");
+        folder.mkdir();
+        assertTrue(folder.exists());
+        DirectoryDeleter.delete(folder);
+        assertFalse(folder.exists());
+    }
+}

--- a/src/test/java/utils/ParserMDTest.java
+++ b/src/test/java/utils/ParserMDTest.java
@@ -1,0 +1,91 @@
+package utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.io.StringReader;
+import org.junit.jupiter.api.Test;
+
+public class ParserMDTest {
+    @Test
+    public void testParsingHasKeys() {
+        String meta =
+                "firstName: \"John\"\n"
+                        + "lastName: \"Doe\"\n"
+                        + "age: 20\n"
+                        + "---\n"
+                        + "This is the content";
+        Reader r = new StringReader(meta);
+        BufferedReader br = new BufferedReader(r);
+
+        var map = ParserContentFile.parse(br);
+        assertNotNull(map.get("firstName"));
+        assertNotNull(map.get("lastName"));
+        assertNotNull(map.get("age"));
+        assertNotNull(map.get("content"));
+    }
+
+    @Test
+    public void testParsingSplitbetweenYamlAndContent() {
+        String meta =
+                "firstName: \"John\"\n"
+                        + "lastName: \"Doe\"\n"
+                        + "age: 20\n"
+                        + "---\n"
+                        + "This is the content";
+        Reader r = new StringReader(meta);
+        BufferedReader br = new BufferedReader(r);
+
+        var map = ParserContentFile.parse(br);
+        assertEquals("John", map.get("firstName"));
+        assertEquals("Doe", map.get("lastName"));
+        assertEquals(20, map.get("age"));
+        assertEquals("This is the content", map.get("content"));
+    }
+
+    @Test
+    public void testParsingWithNoMetaData() {
+        String fileContent = "---\nThis is the content\n but there isnt any meta data";
+        Reader r = new StringReader(fileContent);
+        BufferedReader br = new BufferedReader(r);
+        var map = ParserContentFile.parse(br);
+        assertEquals("This is the content\n but there isnt any meta data", map.get("content"));
+        assertEquals(1, map.keySet().size());
+    }
+
+    @Test
+    public void testParsingWithNoDelimiterIsConsideredAsContentWithNoMetadata() {
+        String fileContent = "firstName: \"John\"\n" + "lastName: \"Doe\"\n" + "age: 20\n";
+        Reader r = new StringReader(fileContent);
+        BufferedReader br = new BufferedReader(r);
+        var map = ParserContentFile.parse(br);
+        assertTrue(map.containsKey("content"));
+        assertEquals(1, map.keySet().size());
+        assertEquals(
+                "firstName: \"John\"\n" + "lastName: \"Doe\"\n" + "age: 20", map.get("content"));
+    }
+
+    @Test
+    public void testParsingComlexYaml() {
+        String fileContent =
+                "employees:\n"
+                        + "    - \n"
+                        + "        id: 213\n"
+                        + "        name: franc\n"
+                        + "        others:\n"
+                        + "            - { department: sales, did: 1} \n"
+                        + "            - { salary: 5000}\n"
+                        + "            - { address: USA, pincode: 97845 }\n"
+                        + "---\n"
+                        + "This is the content";
+        Reader r = new StringReader(fileContent);
+        BufferedReader br = new BufferedReader(r);
+        var map = ParserContentFile.parse(br);
+        System.out.println(map);
+
+        System.out.println(map.get("employees"));
+        assertTrue(map.containsKey("employees"));
+        assertTrue(map.containsKey("content"));
+    }
+}


### PR DESCRIPTION
Le temps total de travail est d'environ 9h

Cette pull request fait le changement de pandoc à handlebar pour la commande de build. Elle close #61, close #67 close #69 et close #70
La commande de build se passe de la manière suivante désormais : 
 - On récupère les fichiers de contenu dans content
 - On charge les templates
  - Pour chaque fichier qui finis en .md : 
    - on parse les metadonnées et le contenu
    - Le contenu est transformé de md à html
    - Le contenu html est inséré dans une map
    - On injecte dans le layout le contenu et les meta données
 - Sinon copier le fichier qui ne finis pas en .md dans le répertoire de build

On peut injecté des fichiers html entier grâce à {{>nomDeFichier}} directement depuis le layout


Cette pull request est accompagné de teste, vous pouvez y voir l'utilisation de build, j'ai aussi ajouté un site d'exemple dans les ressources qui est utilisé durant les testes.

J'ai ajouté les libraires suivante dans le pom.xml 
 - commons-io de apache pour copier des repertoires
 - slf4j-simple pour enlever un warning
 - snakeyaml pour parser les meta données en yaml
 - flexmark-all pour transformer le contenu md en html
 - handlebars pour le templating
 
