### PR TITLE
Feature init template

### DIFF
--- a/src/main/java/commands/Init.java
+++ b/src/main/java/commands/Init.java
@@ -1,17 +1,16 @@
 package commands;
 
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Parameters;
-
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.concurrent.Callable;
+import org.apache.commons.io.FileUtils;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
 
+/** Cette classe est utilisée en conjonction avec picocli pour initialiser un site static. */
 @Command(name = "init", description = "Initialise un dossier pour le site statique")
 public class Init implements Callable<Integer> {
     // Chemin vers le template
@@ -25,22 +24,24 @@ public class Init implements Callable<Integer> {
         if (path == null) {
             throw new NullPointerException("PATH ne doit pas etre null");
         }
-        // Crée le File associé au path
-        File destination = new File(path + "/index.md");
-        // Vérifie si le dossier existe déjà
-        if (destination.exists()) {
-            System.err.println("Le dossier existe déjà");
+        var ri = Build.class.getClassLoader().getResource("exempleSite");
+        if (ri == null) {
+            throw new RuntimeException("Le dossier exempleSite n'a pas été trouvé");
+        }
+        if (Files.exists(Path.of(Paths.get(path).toString(), "content"))) {
+            System.err.println(
+                    "Le dossier "
+                            + Path.of(Paths.get(path).toString(), "content")
+                            + " existe  déjà");
             return -1;
         }
-        if (!destination.mkdirs()) {
-            System.err.println("Impossible de créer le dossier");
+        try {
+            var srcFile = Path.of(ri.getPath()).toFile();
+            FileUtils.copyDirectory(srcFile, Path.of(path).toFile());
+        } catch (IOException e) {
+            e.printStackTrace();
             return -1;
         }
-
-        // Copie le template dans le dossier créé
-        Files.copy(TEMPLATE_PATH, destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        System.out.println("Template créé ici: " + destination.toPath());
         return 0;
     }
-
 }

--- a/src/test/java/commands/InitTest.java
+++ b/src/test/java/commands/InitTest.java
@@ -1,14 +1,14 @@
 package commands;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import utils.DirectoryDeleter;
 
 public class InitTest {
     private static final String TEST_PATH_1 = "test1/site/";
@@ -17,7 +17,7 @@ public class InitTest {
     @Test
     public void testInitWithoutParameterThrowsException() {
         Init init = new Init();
-        //assert que init sans paramètre lance une exception
+        // assert que init sans paramètre lance une exception
         NullPointerException thrown = assertThrows(NullPointerException.class, init::call);
 
         assertEquals("PATH ne doit pas etre null", thrown.getMessage());
@@ -27,7 +27,7 @@ public class InitTest {
     public void testInitWithParameterWorks() throws URISyntaxException, IOException {
         Init init = new Init();
         init.path = TEST_PATH_1;
-        //assert que init retourne sans erreur
+        // assert que init retourne sans erreur
         assertEquals(init.call(), 0);
     }
 
@@ -35,9 +35,9 @@ public class InitTest {
     public void testInitOnDirectoryThatExistsDoesntWork() throws URISyntaxException, IOException {
         Init init = new Init();
         init.path = TEST_PATH_2;
-        //assert que init retourne sans erreur
+        // assert que init retourne sans erreur
         assertEquals(init.call(), 0);
-        //essayer de refaire un init sur le meme path provoque une erreur
+        // essayer de refaire un init sur le meme path provoque une erreur
         assertEquals(init.call(), -1);
     }
 
@@ -45,25 +45,13 @@ public class InitTest {
     public void testInitWithInvalidParameterReturnsError() throws URISyntaxException, IOException {
         Init init = new Init();
         init.path = "/&abc\\";
-        //assert que init retourne une erreur
+        // assert que init retourne une erreur
         assertEquals(init.call(), -1);
     }
 
     @AfterAll
     public static void deleteDirectories() {
-        File directory1 = new File(TEST_PATH_1);
-        deleteDirectory(directory1);
-        File directory2 = new File(TEST_PATH_2);
-        deleteDirectory(directory2);
-    }
-
-    private static void deleteDirectory(File directory) {
-        File[] allContents = directory.listFiles();
-        if (allContents != null) {
-            for (File file : allContents) {
-                deleteDirectory(file);
-            }
-        }
-        directory.delete();
+        DirectoryDeleter.delete(Path.of("test1").toFile());
+        DirectoryDeleter.delete(Path.of("test2").toFile());
     }
 }


### PR DESCRIPTION
closes #68 
 - Temps passé : 
 10'
 - Qu'est-ce que cette PR va changer ?
 Cette PR apporte la nouvelle version de la commande init, désormais on peut utiliser les fonctionnalités des templates.
l'init change la structure du site static, cette nouvelle version de la structure du site statique est déjà documentée dans le [readme.md](https://github.com/dil-classroom/projet-egger_gehring_schaller_vogel#commande-init) grâce à #75 
- Pourquoi l'a-t-on changé ?
Afin de supporter les templates dans le site static
- Comment l'a-t-on testé ?
Les testes utilisés sont ceux de l'ancienne version d'init puisque le contrat de la classe ne change pas 
 - Est-ce que cette feature va encore évoluer ?
ça dépendra des prochains sprints, mais pour l'instant non