### PR TITLE
Ajout de test d'integration systeme

### DIFF
--- a/src/test/java/IntegrationTest.java
+++ b/src/test/java/IntegrationTest.java
@@ -1,0 +1,64 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import commands.Build;
+import commands.Clean;
+import commands.Init;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import utils.DirectoryDeleter;
+
+public class IntegrationTest {
+    private static final String TEST_DIR = "test_dir";
+
+    @AfterEach
+    void tearDown() {
+        DirectoryDeleter.delete(Path.of(TEST_DIR).toFile());
+    }
+
+    @Test
+    void initThenBuildShouldWork() {
+        var init = new Init();
+        var build = new Build();
+        init.path = TEST_DIR;
+        build.rootDirectory = Path.of(TEST_DIR).toFile();
+        try {
+            assertEquals(0, init.call());
+            assertFalse(Path.of(TEST_DIR, "build").toFile().exists());
+            assertEquals(0, build.call());
+            assertTrue(Path.of(TEST_DIR, "build").toFile().exists());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Exception thrown" + e.getMessage());
+        }
+        assertTrue(Path.of(TEST_DIR).toFile().exists());
+        assertTrue(Path.of(TEST_DIR, "template").toFile().exists());
+        assertTrue(Path.of(TEST_DIR, "content").toFile().exists());
+    }
+
+    @Test
+    void initThenBuildThenCleanShouldWork() {
+        var init = new Init();
+        var build = new Build();
+        var clean = new Clean();
+
+        init.path = TEST_DIR;
+        build.rootDirectory = Path.of(TEST_DIR).toFile();
+        clean.site = Path.of(TEST_DIR);
+        try {
+            assertEquals(0, init.call());
+            assertFalse(Path.of(TEST_DIR, "build").toFile().exists());
+            assertEquals(0, build.call());
+            assertTrue(Path.of(TEST_DIR, "build").toFile().exists());
+            assertEquals(clean.call(), 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Exception thrown" + e.getMessage());
+        }
+        assertTrue(Path.of(TEST_DIR).toFile().exists());
+        assertTrue(Path.of(TEST_DIR, "template").toFile().exists());
+        assertTrue(Path.of(TEST_DIR, "content").toFile().exists());
+        assertFalse(Path.of(TEST_DIR, "build").toFile().exists());
+    }
+}


### PR DESCRIPTION
- Temps passé 25'
- Qu'est-ce que cette PR va changer ?
Elle ajoute des testes d'intégrations qui vérifie que les commandes passées les une après les autres fonctionnent toutes, ainsi on peut verifier le comportement du système dans son ensemble et non plus chaque partie de manière individuel
- Pourquoi l'a-t-on changé ?
Il n'y avait pas de teste d'intégration
- Comment l'a-t-on testé ?
ce sont des testes donc ils testent eux même
- Est-ce que cette feature va encore évoluer ?
Si des nouvelles commandes sont implémentées, il faudrait les tester en commun avec les commandes existantes.

Closes #65